### PR TITLE
Integrates Simu5G in the cookiecutter generation process

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,5 +8,6 @@
     "use_veins_vlc": ["no", "yes"],
     "use_plexe_veins": ["no", "yes"],
     "use_simulte": ["no", "yes"],
+    "use_simu5g": ["no", "yes"],
     "_dummy": ""
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -20,7 +20,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
-
+import os
 import subprocess
 
 print('Cookiecutter successful. Running git commands to set up repository.')
@@ -62,6 +62,12 @@ subprocess.check_call(['git', 'subtree', 'add', '--prefix=plexe_veins', '--messa
 subprocess.check_call(['git', 'subtree', 'add', '--prefix=simulte', '--message', 'Merge SimuLTE 1.1.0', 'https://github.com/inet-framework/simulte.git', 'v1.1.0'])
 {%- endif %}
 
+# Simu5G
+{%- if cookiecutter.use_simu5g == "yes" %}
+subprocess.check_call(['git', 'subtree', 'add', '--prefix=simu5g', '--message', 'Merge Simu5G Master', 'https://github.com/Unipisa/Simu5G.git', 'master'])
+
+{%- endif %}
+
 # Veins
 subprocess.check_call(['git', 'subtree', 'add', '--prefix=veins', '--message', 'Merge Veins 5.1', 'https://github.com/sommer/veins', 'veins-5.1'])
 
@@ -72,5 +78,34 @@ subprocess.check_call(['git', 'commit', '--message', '{{ cookiecutter.project_na
 print('Repository set up successful. Running git commands to clean up.')
 subprocess.check_call(['git', 'config', '--unset', 'user.name'])
 subprocess.check_call(['git', 'config', '--unset', 'user.email'])
+
+
+
+# Change inet references for Simu5G to 'inet' instead of 'inet4'
+{%- if cookiecutter.use_simu5g == "yes" %}
+
+# '.project' file
+with open(os.getcwd() + "/simu5g/.project", "r") as file:
+    data = file.readlines()
+data[5] =" 		<project>inet</project>\n<project>veins</project>\n<project>veins_inet</project>\n"
+with open(os.getcwd() + "/simu5g/.project", "w") as file:
+    file.writelines(data)
+
+# Makefile
+with open(os.getcwd() + "/simu5g/Makefile", "r") as file:
+    data = file.readlines()
+data[15] ="	@cd src && opp_makemake --make-so -f --deep -o simu5g -O out -KINET_PROJ=../../inet -DINET_IMPORT -I. -I$$\(INET_PROJ\)/src -L$$\(INET_PROJ\)/src -lINET$$\(D\)\n"
+with open(os.getcwd() + "/simu5g/Makefile", "w") as file:
+    file.writelines(data)
+
+# bin
+with open(os.getcwd() + "/simu5g/bin/simu5g", "r") as file:
+    data = file.readlines()
+data[3] ="INET_SRC=`(cd $SIMU5G_ROOT/../inet/src ; pwd)`\n"
+with open(os.getcwd() + "/simu5g/bin/simu5g", "w") as file:
+    file.writelines(data)
+
+{%- endif %}
+
 
 print('Cookiecutter successful.')

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -30,6 +30,7 @@ project_name_as_macro_name = '{{ cookiecutter.project_name_as_macro_name }}'
 use_inet = '{{ cookiecutter.use_inet }}'
 use_inet3 = '{{ cookiecutter.use_inet3 }}'
 use_simulte = '{{ cookiecutter.use_simulte }}'
+use_simu5g = '{{ cookiecutter.use_simu5g }}'
 
 print('Cookiecutter checks starting.')
 
@@ -50,6 +51,10 @@ if use_inet == "yes" and use_inet3 == "yes":
 
 if use_simulte == "yes" and use_inet3 != "yes":
     print('ERROR: use_simulte requires use_inet3 (SimuLTE requires INET version 3).')
+    sys.exit(1)
+
+if use_simu5g == "yes" and use_inet == "no":
+    print('ERROR: use_simu5g requires use_inet (SIMU5G requires INET version 4).')
     sys.exit(1)
 
 print('Cookiecutter checks successful.')

--- a/{{cookiecutter.project_name_as_file_name}}/Makefile
+++ b/{{cookiecutter.project_name_as_file_name}}/Makefile
@@ -49,6 +49,14 @@ endif
 {%- if cookiecutter.use_plexe_veins == "yes" %}
 	$(MAKE) -C plexe_veins all
 {%- endif %}
+{%- if cookiecutter.use_simu5g == "yes" %}
+ifdef MODE
+	$(MAKE) -C simu5g all
+else
+	$(MAKE) -C simu5g all MODE=release
+	$(MAKE) -C simu5g all MODE=debug
+endif
+{%- endif %}
 {%- if cookiecutter.use_simulte == "yes" %}
 ifdef MODE
 	$(MAKE) -C simulte all
@@ -74,6 +82,9 @@ clean:
 {%- endif %}
 {%- if cookiecutter.use_plexe_veins == "yes" %}
 	$(MAKE) -C plexe_veins clean
+{%- endif %}
+{%- if cookiecutter.use_simu5g == "yes" %}
+	$(MAKE) -C simu5g clean
 {%- endif %}
 {%- if cookiecutter.use_simulte == "yes" %}
 	$(MAKE) -C simulte clean

--- a/{{cookiecutter.project_name_as_file_name}}/configure
+++ b/{{cookiecutter.project_name_as_file_name}}/configure
@@ -42,5 +42,9 @@ set -e
 {%- if cookiecutter.use_simulte == "yes" %}
 (cd simulte && make makefiles)
 {%- endif %}
+{%- if cookiecutter.use_simu5g == "yes" %}
+(cd simu5g && make makefiles)
+{%- endif %}
+
 (cd {{ cookiecutter.project_name_as_file_name }} && ./configure "$@")
 

--- a/{{cookiecutter.project_name_as_file_name}}/{{cookiecutter.project_name_as_file_name}}/.project
+++ b/{{cookiecutter.project_name_as_file_name}}/{{cookiecutter.project_name_as_file_name}}/.project
@@ -18,6 +18,9 @@
 {%- if cookiecutter.use_plexe_veins == "yes" %}
 		<project>plexe-veins</project>
 {%- endif %}
+{%- if cookiecutter.use_simu5g == "yes" %}
+		<project>simu5G</project>
+{%- endif %}
 {%- if cookiecutter.use_simulte == "yes" %}
 		<project>lte</project>
 {%- endif %}

--- a/{{cookiecutter.project_name_as_file_name}}/{{cookiecutter.project_name_as_file_name}}/configure
+++ b/{{cookiecutter.project_name_as_file_name}}/{{cookiecutter.project_name_as_file_name}}/configure
@@ -61,6 +61,9 @@ parser.add_option("--with-plexe-veins", dest="plexe_veins", help="link with a ve
 {%- if cookiecutter.use_simulte == "yes" %}
 parser.add_option("--with-simulte", dest="simulte", help="link with a version of SimuLTE installed in PATH", metavar="PATH", default="../simulte")
 {%- endif %}
+{%- if cookiecutter.use_simu5g == "yes" %}
+parser.add_option("--with-simu5g", dest="simu5g", help="link with a version of SimuLTE installed in PATH", metavar="PATH", default="../simu5g")
+{%- endif %}
 {%- if cookiecutter.use_inet == "yes" %}
 parser.add_option("--with-inet", dest="inet", help="link with a version of the INET Framework installed in PATH", metavar="PATH", default="../inet")
 parser.add_option("--with-veins-inet", dest="veins_inet", help="link with a version of Veins_INET installed in PATH", metavar="PATH", default="../veins/subprojects/veins_inet")
@@ -333,6 +336,22 @@ if options.simulte:
     run_libs = [os.path.relpath(os.path.join(options.simulte, 'src', 'lte'))] + run_libs
     run_neds = [os.path.relpath(os.path.join(options.simulte, 'src'))] + run_neds
     run_imgs = [os.path.relpath(os.path.join(options.simulte, 'images'))] + run_imgs
+{%- endif %}
+{%- if cookiecutter.use_simu5g == "yes" %}
+
+# Add flags for Simu5G
+if options.simu5g:
+    fname = os.path.join(options.simu5g, 'Version')
+
+    simu5g_header_dirs = [os.path.join(os.path.relpath(options.simu5g, 'src'), 'src')]
+    simu5g_includes = ['-I' + s for s in simu5g_header_dirs]
+    simu5g_link = ["-L" + os.path.join(os.path.relpath(options.simu5g, 'src'), 'src'), "-lsimu5g$(D)"]
+    simu5g_defs = []
+
+    makemake_flags += simu5g_includes + simu5g_link + simu5g_defs
+    run_libs = [os.path.relpath(os.path.join(options.simu5g, 'src', 'simu5G'))] + run_libs
+    run_neds = [os.path.relpath(os.path.join(options.simu5g, 'src'))] + run_neds
+    run_imgs = [os.path.relpath(os.path.join(options.simu5g, 'images'))] + run_imgs
 {%- endif %}
 
 


### PR DESCRIPTION
This pull request integrates Simu5G into the veins cookiecutter project.
Since Simu5G does not offer any tags, it will use the current master branch.

Simu5G requires that the directory of INET framework is always named "inet4". 
During the cookiecutter setup process, corresponding files of Simu5G (.project, Makefile, bin/simu5g) are changed so that the build process in the IDE and on the command line works with the directory name "inet" (which is also used by all other frameworks provided by this project).